### PR TITLE
Always show title-edit and extras buttons on screens 1024px and smaller.

### DIFF
--- a/assets/css/wp-dashboard-notes-admin.scss
+++ b/assets/css/wp-dashboard-notes-admin.scss
@@ -325,3 +325,15 @@ span.wpdn-color-note:hover .wpdn-color-palette {
 [data-color-text=template] .saving-icon {
 	color: inherit;
 }
+
+/****************************
+ * Mobile Adjustments
+****************************/
+@media (max-width: 1024px) {
+	.wpdn-extra{
+		opacity:1
+	}
+	.wpdn-edit-title {
+		display: inline-block !important;
+	}
+}


### PR DESCRIPTION
Adding a simple media query to always show buttons that would otherwise require hover on devices with screen sizes of 1024px and smaller.